### PR TITLE
Fix program success comparison when using groups

### DIFF
--- a/include/bUnitTests.h
+++ b/include/bUnitTests.h
@@ -401,7 +401,8 @@ int main()
 
     // returns the "pass" value if all tests pass, or the "fail" value if any tests fail
     return (
-        g_successes == get_tests().size() ? static_cast<int>(ReturnValue::pass) : static_cast<int>(ReturnValue::fail));
+        g_successes == get_number_of_tests() ? static_cast<int>(ReturnValue::pass)
+                                             : static_cast<int>(ReturnValue::fail));
 }
 #    endif // bBUILD_TESTS
 #    undef bTEST_IMPLEMENTATION
@@ -435,15 +436,15 @@ int main()
 //      bTEST_FUNCTION(repeatable_tokenization_and_serialization, "tokenizing")
 //      {
 //          std::string inputString{...};
-//      
+//
 //          auto tokens1 = tokenize(inputString);
-//      
+//
 //          auto toString = stringify(tokens1);
-//      
+//
 //          auto tokens2 = tokenize(toString);
-//      
+//
 //          bTEST_ASSERT(tokens1.size() == tokens2.size());
-//      
+//
 //          for (auto idx = 0; idx < tokens1.size(); idx++)
 //          {
 //              bTEST_ASSERT(tokens1.at(idx) == tokens2.at(idx));


### PR DESCRIPTION
Closes #5.

The problem was exactly as outlined in the issue, as was the fix.

Simple fix --_and_ it has been tested!

Some slight formatting of the document may have changed, but the content remains unchanged other than the fix.